### PR TITLE
Add #hasChild helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,34 @@ exports.hasChildren = function (node, children) {
 };
 
 /**
+ * Check if the given `node` at a given `index` has the corresponding `child`,
+ * using the following `criteria`:
+ *
+ *  - When a `Function`, it will run `criteria`, passing the child node as an
+ *    argument. `criteria` is expected to throw an error if the node is invalid.
+ *  - Otherwise, it will do a deep comparison between the child node and
+ *    the criteria.
+ *
+ * @param {Object} node        The virtual node to check.
+ * @param {number} index       The index of the child to inspect. Zero indexed.
+ * @param {*}      [criteria]  The criteria for the child nodes. (see above)
+ */
+exports.hasChild = function (node, index, criteria) {
+  if (arguments.length === 2) criteria = noop;
+  exports.isNode(node);
+  assert(node.children.length > 0, 'provided node has no children');
+  assert(typeof index === 'number', 'provided index is not a number');
+  assert(index >= 0, 'provided index cannot be negative');
+  var child = node.children[index];
+  assert(child !== undefined, 'child does not exist at the given index');
+  if (typeof criteria === 'function') {
+    criteria(child);
+  } else {
+    assert.deepEqual(child, criteria);
+  }
+};
+
+/**
  * Ensures that the given `node` does not have any child nodes.
  *
  * @param {Object} node  The virtual node to check.
@@ -125,3 +153,8 @@ function classes(input) {
   if (!input.trim()) return [];
   return input.trim().split(/\s+/g);
 }
+
+/**
+ * No operation.
+ */
+function noop() {}

--- a/test/index.js
+++ b/test/index.js
@@ -151,7 +151,7 @@ describe('node', function () {
     });
   });
 
-  describe('.hasChildren(node, children)', function () {
+  describe('.hasChild(node, child, children)', function () {
     it('should throw when missing the node', fail(function () {
       assertions.hasChildren();
     }));
@@ -199,6 +199,65 @@ describe('node', function () {
         throw new Error('fail');
       }
     }));
+  });
+
+  describe('.hasChild(node, index, [fn])', function () {
+    it('should throw when missing the node', fail(function () {
+      assertions.hasChild();
+    }));
+
+    it('should throw for objects that are not virtual nodes', fail(function () {
+      assertions.hasChild({});
+    }));
+
+    it('should throw when there are no children', fail(function () {
+      assertions.hasChild(element('div'));
+    }));
+
+    it('should throw when an index is not provided', fail(function () {
+      assertions.hasChild(element('div', null, 'hello world'));
+    }));
+
+    it('should throw when a negative index is provided', fail(function () {
+      assertions.hasChild(element('div', null, 'hello world'), -1);
+    }));
+
+    it('should throw when a child at the given index does not exist', fail(function () {
+      assertions.hasChild(element('div', null, 'a'), 1);
+    }));
+
+    it('should not throw when there are children and an index is provided', function () {
+      assertions.hasChild(element('div', null, 'hello world'), 0);
+    });
+  });
+
+  describe('.hasChild(node, index, criteria)', function () {
+    describe('criteria is not a function', function() {
+      it('should not throw when the deep comparison succeeds', function() {
+        assertions.hasChild(element('div', null, 'a', 'b'), 0, 'a');
+        assertions.hasChild(element('div', null, 'a', 'b'), 1, 'b');
+      });
+
+      it('should throw when the deep comparison fails', fail(function() {
+        assertions.hasChild(element('div', null, 'a', 'b'), 0, 'b');
+      }));
+    });
+
+    describe('criteria is a function', function() {
+      it('should throw when `criteria` throws', fail(function () {
+        assertions.hasChild(element('div', null, 'a', 'b'), 0, test);
+
+        function test(child) {
+          throw new Error('fail');
+        }
+      }));
+
+      it('should not throw when `criteria` does not throw', function () {
+        assertions.hasChild(element('div', null, 'a'), 0, test);
+
+        function test(child) {}
+      });
+    });
   });
 
   describe('.notHasChildren(node)', function () {


### PR DESCRIPTION
`hasChild` is a singular version of `hasChildren`, allowing you to run
assertions on a given child. Example usage:

``` js
// Asserts that a child exists at index 0
assert.hasChild(node, 0);
// Does a deep comparison on the child; in this case, checking if it's a
// Menu component
assert.hasChild(node, 0, Menu);
// Accepts a callback to run assertions on a child
assert.hasChild(node, 0, function(child) {
  assert.isNode(child, 'div');
  assert.hasClass(child, 'navbar');
});
```

cc @dominicbarnes 
